### PR TITLE
feat: order model and backend approach

### DIFF
--- a/db/models/order-product.js
+++ b/db/models/order-product.js
@@ -1,0 +1,21 @@
+/*
+
+This is a join table between Order and Product that stores priceAtOrderTime and quantity for each product in your order. Order can sum a total based on this. TODO: Discuss this approach.
+
+*/
+
+const { DECIMAL, INTEGER } = require('Sequelize')
+
+module.exports = db => db.define('orderproduct', {
+  priceAtOrderTime: {
+    type: DECIMAL(13, 4)
+  },
+  quantity: {
+    type: INTEGER
+  }
+})
+
+module.exports.associations = (OrderProduct, {Order, Product}) => {
+  OrderProduct.belongsTo(Order)
+  Order.hasMany(OrderProduct)
+}

--- a/db/models/order-product.js
+++ b/db/models/order-product.js
@@ -17,5 +17,5 @@ module.exports = db => db.define('orderproduct', {
 
 module.exports.associations = (OrderProduct, {Order, Product}) => {
   OrderProduct.belongsTo(Order)
-  Order.hasMany(OrderProduct)
+  OrderProduct.hasMany(Product)
 }

--- a/db/models/order.js
+++ b/db/models/order.js
@@ -1,6 +1,5 @@
 module.exports = db => db.define('order', {}, {})
 
-module.exports.associations = (Order, {User, Favorite}) => {
+module.exports.associations = (Order, {User}) => {
   Order.belongsTo(User)
-  User.hasMany(Order)
 }

--- a/db/models/order.js
+++ b/db/models/order.js
@@ -1,0 +1,6 @@
+module.exports = db => db.define('order', {}, {})
+
+module.exports.associations = (Order, {User, Favorite}) => {
+  Order.belongsTo(User)
+  User.hasMany(Order)
+}


### PR DESCRIPTION
I split the backend orders approach into two tables: 

**order** simply maintains an orderId and the userId associated with it. Long-term, we may also want to include total price and other information at the order level. 

**order-product** associates an orderId with an itemId, plus the quantity and priceAtTimeOfOrder for each. 

This is a best practice according to StackOverflow: http://stackoverflow.com/questions/2000833/best-structure-for-orders-table-having-multiple-items-per-order-number 

Let's talk through it!